### PR TITLE
Fix ActionUpdateThread deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ jobs:
   include:
     - stage: Build and Test
       env: ORG_GRADLE_PROJECT_ideaVersion=LATEST-EAP-SNAPSHOT
-    - env: ORG_GRADLE_PROJECT_ideaVersion=2022.2
+    - env: ORG_GRADLE_PROJECT_ideaVersion=2022.3
 #    - env: ORG_GRADLE_PROJECT_ideaVersion=2017.1.5
     - stage: Deploy new Release
       script: skip
-      env: ORG_GRADLE_PROJECT_ideaVersion=2022.2
+      env: ORG_GRADLE_PROJECT_ideaVersion=2022.3
       deploy:
         - provider: script
           script: ./gradlew publishPlugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Bug fixes
+- Fix `com.intellij.diagnostic.PluginException: ActionUpdateThread.OLD_EDT is deprecated and going to be removed soon.
+  'com.aemtools.action.MarkAsHtlRootDirectoryAction' must override getActionUpdateThread() and chose EDT or BGT`
+
+### Maintenance
+- Dropped support for Intellij version 222 (2022.2) due to the above.
+
+## [1.0.5]
+[1.0.5]: https://github.com/aemtools/aemtools/tree/v1.0.5
+### Maintenance
+- Compatibility with the latest Intellij versions (242.+)
+
 ## [1.0.4]
 [1.0.4]: https://github.com/aemtools/aemtools/tree/v1.0.4
 ### New features

--- a/aem-intellij-core/build.gradle.kts
+++ b/aem-intellij-core/build.gradle.kts
@@ -95,7 +95,7 @@ tasks {
   runPluginVerifier {
     enabled = true
     subsystemsToCheck.set("without-android")
-    ideVersions.set(listOf("IC-2022.2.5", "IC-2022.3.3", "IC-2023.1.1", "IC-2023.3", "IC-2024.1", "IC-2024.2"))
+    ideVersions.set(listOf("IC-2022.3.3", "IC-2023.1.1", "IC-2023.3", "IC-2024.1", "IC-2024.2"))
     dependsOn(listProductsReleases)
   }
   verifyPlugin { enabled = true }

--- a/aem-intellij-core/src/main/kotlin/com/aemtools/action/MarkAsHtlRootDirectoryAction.kt
+++ b/aem-intellij-core/src/main/kotlin/com/aemtools/action/MarkAsHtlRootDirectoryAction.kt
@@ -6,6 +6,7 @@ import com.aemtools.lang.htl.icons.HtlIcons
 import com.aemtools.lang.htl.service.HtlDetectionService
 import com.aemtools.lang.settings.HtlRootDirectories
 import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.DumbAwareAction
@@ -22,6 +23,10 @@ import com.intellij.util.FileContentUtil.reparseOpenedFiles
  * @author Dmytro Primshyts
  */
 class MarkAsHtlRootDirectoryAction : DumbAwareAction() {
+
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.BGT
+  }
 
   override fun update(event: AnActionEvent) {
     val file = event.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY)

--- a/aem-intellij-core/src/main/resources/META-INF/plugin.xml
+++ b/aem-intellij-core/src/main/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
     <depends optional="true" config-file="expression-language.xml">com.intellij.modules.lang</depends>
     <depends optional="true" config-file="jcr-property-language.xml">com.intellij.modules.lang</depends>
 
-    <idea-version since-build="222"/>
+    <idea-version since-build="223"/>
 
     <extensions defaultExtensionNs="com.intellij">
 

--- a/aem-intellij-core/src/test/kotlin/com/aemtools/action/MarkAsHtlRootDirectoryActionActionPerformedTest.kt
+++ b/aem-intellij-core/src/test/kotlin/com/aemtools/action/MarkAsHtlRootDirectoryActionActionPerformedTest.kt
@@ -16,8 +16,7 @@ class MarkAsHtlRootDirectoryActionActionPerformedTest
 
   var targetAction: MarkAsHtlRootDirectoryAction = MarkAsHtlRootDirectoryAction()
 
-  //FIXME test
-  /*@Test
+  @Test
   fun `actionPerformed should ignore if presentation is disabled`() {
     `when`(actionEvent.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY))
       .thenReturn(arrayOf(virtualFile));
@@ -110,6 +109,6 @@ class MarkAsHtlRootDirectoryActionActionPerformedTest
 
     verify(rootDirectories).removeRoot("/jcr_root/directory")
     verify(rootDirectories, never()).addRoot("/jcr_root/directory")
-  }*/
+  }
 
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ environment:
   JAVA_HOME: C:\Program Files\Java\jdk17
   JAVA_OPTS: "-Xms256m -Xmx2048M -Djdk.tls.client.protocols=TLSv1.2"
   matrix:
-    - ORG_GRADLE_PROJECT_ideaVersion: 2022.2
+    - ORG_GRADLE_PROJECT_ideaVersion: 2022.3
 #cache:
 #  - C:\Users\appveyor\.gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = aemtools
 pluginName = aemtools
-pluginVersion = 1.0.5
+pluginVersion = 1.0.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 222
+pluginSinceBuild = 223
 pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Version 1.0.5 prints this **IDE Internal Error** message on Intellij 2024.2:
```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'com.aemtools.action.MarkAsHtlRootDirectoryAction' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: com.aemtools]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:201)
```

Fixed it by using `BGT` (https://plugins.jetbrains.com/docs/intellij/basic-action-system.html#anactiongetactionupdatethread)

Needed to drop support for 2022.2 because of that (see https://github.com/redhat-developer/intellij-common/issues/218).